### PR TITLE
Spike Lua filter to set filename date as meta date

### DIFF
--- a/_filters/post_date_from_filename.lua
+++ b/_filters/post_date_from_filename.lua
@@ -1,0 +1,27 @@
+function post_date_from_filename(doc)
+  local m = doc.meta
+  if m.date == nil then
+    pattern = "(%d%d%d%d)%-(%d%d)%-(%d%d)%-[%a%d][%a%d%-]+[%a%d]%.md"
+    --matches = string.match(pandoc.path.filename(), pattern)
+    --year = matches[0]
+    --month = matches[1]
+    --day = matches[2]
+
+
+    print(m)
+
+    --m.date = os.date({year=year, month=month, day=day})
+    --m.date = os.time
+
+    return m
+  end
+end
+
+return {{
+  Pandoc = function(doc)
+    print(doc)
+    local meta = insert_post_date_from_filename(doc)
+
+    return pandoc.Pandoc(doc.blocks, meta)
+  end
+  }}

--- a/posts/2023-09-22-migrating-website.md
+++ b/posts/2023-09-22-migrating-website.md
@@ -1,0 +1,9 @@
+---
+pandoc:
+  filters:
+    - _filters/post_date_from_filename.lua
+---
+
+# Migrating my website
+
+stuff


### PR DESCRIPTION
Add an attempt at a Lua filter that will extract a date string from a filename, and insert it into the metadata field
for that page.

This matches Jekyll's default blog posts behavior, where `_posts/2023-01-01-my-great-post.md` becomes a post with a date
of 2023-01-01.

This work is a precursor to attempting to massage the slugs for some pages in the Emanote site, such that

`posts/2023-01-01-my-awesome-post.md`

could be served from

`SITE_URL/posts/2023/01/my-awesome-post.html`
